### PR TITLE
#160920764 Fix error with countdown timer

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: npm start
+web: yarn start

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build:server": "babel ./src/server.js -d ./build",
     "build:client": "webpack --mode production",
-    "heroku-postbuild": "npm run build:client && npm run build:server",
+    "heroku-postbuild": "yarn build:client && yarn build:server",
     "start": "node ./build/src/server.js",
     "start:dev": "webpack-dev-server --mode=development --inline --hot"
   },

--- a/src/components/Game.jsx
+++ b/src/components/Game.jsx
@@ -207,12 +207,14 @@ class Game extends Component {
         return {
           doneStatus: 'Done, Nice!',
           countdownRunning: false,
+          customTime: false,
         };
       }
       if (prevState.redraws === 0 && !this.possibleSolutions(prevState)) {
         return {
           doneStatus: 'Game Over!',
           countdownRunning: false,
+          customTime: false,
         };
       }
       if (!prevState.countdownRunning) {


### PR DESCRIPTION
#### What does this PR do?
- Fix error is timer not reverting to default when the game ends with win or loss.
#### Description of Task to be completed?
- The countdown timer should revert to the default if another game round it started without setting a custom time for that round
#### How should this be manually tested?
- Pull and checkout to the branch with the command `git fetch origin bg-fix-countdown-timer-160920764:bg-fix-countdown-timer-160920764` `git checkout bg-fix-countdown-timer-160920764`
- Start the application with the command `npm run start:dev` and visit the browser at `localhost:8080`
- Play the game
#### Any background context you want to provide?
- N/A
#### What are the relevant pivotal tracker stories?
- [#160920764](https://www.pivotaltracker.com/story/show/160920764)
#### Screenshots (if appropriate)
- N/A
#### Questions:
- N/A